### PR TITLE
fixed error when line property is 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function (results, data, opts) {
 	}
 	
     function makeAttribute(attr, valueObject) {
-		if (!valueObject[attr]) {
+		if (!valueObject.hasOwnProperty(attr)) {
 			throw Error('No property '+attr+' in error object');
 		}
 


### PR DESCRIPTION
jshint may report errors on line 0, thus fails the check
